### PR TITLE
Add Protobuf version to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ tensorflow==2.7.0
 scikit-learn==0.24.1
 numpy==1.19.2
 pandas==1.2.4
-
+protobuf<=3.20.1
 
 
 


### PR DESCRIPTION
Adding protobuf version to requirements to fix CrashLoopBackOff error upon deployment to OpenShift step of tutorial (error logs found [here](http://pastebin.test.redhat.com/1056755)). 

Deployment was failing as TensorFlow was encountering a TypeError on importing, and issue is fixed by downgrading protobuf (link to solution [here](https://exerror.com/typeerror-descriptors-cannot-not-be-created-directly/)). 



 